### PR TITLE
Fix CSV path used for map data

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,4 +1,6 @@
-const SHEET_URL = 'https://v';
+// Source CSV containing location data. Using a relative path allows
+// the application to work locally without relying on an external URL.
+const SHEET_URL = 'locations.csv';
 
 function convertImageLink(url) {
   const match = url.match(/\/d\/(.*?)\//);


### PR DESCRIPTION
## Summary
- point the map script at the local `locations.csv`

## Testing
- `node --check script.js`
- `node - <<'NODE' ...` (run `parseCSV` on sample data)

------
https://chatgpt.com/codex/tasks/task_e_6847975420d0832997eba1d5deeb35d9